### PR TITLE
Feat/signup form

### DIFF
--- a/src/components/Layouts/SignupLayout.vue
+++ b/src/components/Layouts/SignupLayout.vue
@@ -14,6 +14,7 @@ const props = withDefaults(
 
 const emit = defineEmits<{
   (e: 'back'): void
+  (e: 'logo'): void
 }>()
 
 const progress = computed(() => {
@@ -35,14 +36,18 @@ const progress = computed(() => {
           <span class="sr-only">뒤로가기</span>
         </button>
 
-        <div class="absolute left-1/2 -translate-x-1/2">
+        <button
+          type="button"
+          @click="emit('logo')"
+          class="absolute left-1/2 -translate-x-1/2 rounded-lg px-2 py-1 text-[var(--gray-900)] transition-all hover:bg-[var(--gray-50)] active:scale-95"
+        >
           <span
             class="text-[22px] tracking-[-0.02em]"
             style="font-family: JalnanGothic; font-weight: normal"
           >
             픽<span style="color: #00c73c">잇</span>
           </span>
-        </div>
+        </button>
 
         <div class="w-10" />
       </div>

--- a/src/components/Signup/SignupFlow.vue
+++ b/src/components/Signup/SignupFlow.vue
@@ -35,7 +35,7 @@ type FocusType = 'nutrition' | 'diet' | 'bulkup' | null
 
 const emit = defineEmits<{
   (e: 'complete'): void
-  (e: 'back'): void
+  (e: 'exit'): void
 }>()
 
 const step = ref<SignupStep>('nickname')
@@ -177,6 +177,19 @@ const handleTargetWeightNext = (weight: string) => {
 const handleWelcomeComplete = () => {
   emit('complete')
 }
+
+const handleBack = () => {
+  const order = stepOrder.value
+  const currentIndex = order.indexOf(step.value)
+  if (currentIndex > 0) {
+    const previousStep = order[currentIndex - 1]
+    if (previousStep) {
+      step.value = previousStep
+      return
+    }
+  }
+  emit('exit')
+}
 </script>
 
 <template>
@@ -186,7 +199,8 @@ const handleWelcomeComplete = () => {
     :step-title="stepInfo.title"
     :step-description="stepInfo.description"
     :show-progress="showProgress"
-    @back="emit('back')"
+    @back="handleBack"
+    @logo="emit('exit')"
   >
     <Transition name="fade-slide" mode="out-in">
       <StepNickname v-if="step === 'nickname'" key="nickname" @next="handleNicknameNext" />

--- a/src/components/Signup/SignupFlow.vue
+++ b/src/components/Signup/SignupFlow.vue
@@ -34,7 +34,7 @@ type SignupStep =
 type FocusType = 'nutrition' | 'diet' | 'bulkup' | null
 
 const emit = defineEmits<{
-  (e: 'complete'): void
+  (e: 'complete', payload: SignupResult): void
   (e: 'exit'): void
 }>()
 
@@ -61,6 +61,20 @@ const habits = ref({ smoking: '', drinking: '' })
 const mealCount = ref('')
 const activityLevel = ref('')
 const targetWeight = ref('')
+
+type SignupResult = {
+  nickname: string
+  terms: typeof termsAccepted.value
+  userInfo: typeof userInfo.value
+  allergies: string[]
+  affiliation: { type: typeof affiliationType.value; selected: string }
+  focusType: FocusType
+  diseases: string[]
+  habits: typeof habits.value
+  mealCount: string
+  activityLevel: string
+  targetWeight: string
+}
 
 const stepOrder = computed<SignupStep[]>(() => {
   const order: SignupStep[] = ['nickname', 'terms', 'info', 'allergies', 'affiliation']
@@ -175,7 +189,27 @@ const handleTargetWeightNext = (weight: string) => {
 }
 
 const handleWelcomeComplete = () => {
-  emit('complete')
+  const payload = {
+    nickname: nickname.value,
+    terms: { ...termsAccepted.value },
+    userInfo: { ...userInfo.value },
+    allergies: [...allergies.value],
+    affiliation: {
+      type: affiliationType.value,
+      selected: selectedAffiliation.value,
+    },
+    focusType: focusType.value,
+    diseases: [...diseases.value],
+    habits: { ...habits.value },
+    mealCount: mealCount.value,
+    activityLevel: activityLevel.value,
+    targetWeight: targetWeight.value,
+  } satisfies SignupResult
+
+  // API 연동 전까지 콘솔로 데이터 확인
+  console.log('[Signup] collected payload', payload)
+
+  emit('complete', payload)
 }
 
 const handleBack = () => {

--- a/src/components/Signup/SignupFlow.vue
+++ b/src/components/Signup/SignupFlow.vue
@@ -62,7 +62,7 @@ const mealCount = ref('')
 const activityLevel = ref('')
 const targetWeight = ref('')
 
-type SignupResult = {
+export type SignupResult = {
   nickname: string
   terms: typeof termsAccepted.value
   userInfo: typeof userInfo.value
@@ -216,11 +216,8 @@ const handleBack = () => {
   const order = stepOrder.value
   const currentIndex = order.indexOf(step.value)
   if (currentIndex > 0) {
-    const previousStep = order[currentIndex - 1]
-    if (previousStep) {
-      step.value = previousStep
-      return
-    }
+    step.value = order[currentIndex - 1]!
+    return
   }
   emit('exit')
 }

--- a/src/views/SignupView/SignupView.vue
+++ b/src/views/SignupView/SignupView.vue
@@ -4,7 +4,8 @@ import SignupFlow from '@/components/Signup/SignupFlow.vue'
 
 const router = useRouter()
 
-const handleComplete = () => {
+const handleComplete = (payload: unknown) => {
+  console.log('[Signup] complete payload', payload)
   router.push('/')
 }
 

--- a/src/views/SignupView/SignupView.vue
+++ b/src/views/SignupView/SignupView.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
 import { useRouter } from 'vue-router'
 import SignupFlow from '@/components/Signup/SignupFlow.vue'
+import type { SignupResult } from '@/components/Signup/SignupFlow.vue'
 
 const router = useRouter()
 
-const handleComplete = (payload: unknown) => {
+const handleComplete = (payload: SignupResult) => {
   console.log('[Signup] complete payload', payload)
   router.push('/')
 }

--- a/src/views/SignupView/SignupView.vue
+++ b/src/views/SignupView/SignupView.vue
@@ -8,14 +8,14 @@ const handleComplete = () => {
   router.push('/')
 }
 
-const handleBack = () => {
-  router.back()
+const handleExit = () => {
+  router.push('/login')
 }
 </script>
 
 <template>
   <div class="signup-shell bg-white">
-    <SignupFlow @complete="handleComplete" @back="handleBack" />
+    <SignupFlow @complete="handleComplete" @exit="handleExit" />
   </div>
 </template>
 


### PR DESCRIPTION
## <i>PULL REQUEST</i>
##  feat/signup_form         // 타입: 제목

### 🎋 작업중인 브랜치
- feat/signup_form

### 💡 작업동기
- 뒤로가기 동작을 설계에 맞게 수정하고, 완료시 입력 데이터를 한 번에 확인할 수 있도록 로그를 추가했습니다.

### 🔑 주요 변경사항
 - 백 버튼: 스텝 단위로 이전으로 이동하고 첫 스텝에서는 /login으로 나가도록 변경.
  - 상단 픽잇 로고: 클릭 시 /login으로 이동함.                             
  - 가입 완료 시 모든 입력값을 콘솔에 띄움

### 스크린샷
<img width="1252" height="733" alt="image" src="https://github.com/user-attachments/assets/297817cc-4bf9-4077-babe-9eea9bc93b58" />
로고 클릭시 /login 그리고 백버튼 누를시 이전
<img width="1388" height="714" alt="image" src="https://github.com/user-attachments/assets/5c6b2997-2731-4a87-ba60-0c1776d30b1d" />
