### PR TITLE
Feat/api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+.env*
 
 # Editor directories and files
 .vscode/*

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ dist-ssr
 *.sw?
 
 AGENTS.md
+AI

--- a/src/mocks/auth.ts
+++ b/src/mocks/auth.ts
@@ -1,0 +1,27 @@
+import type { BasicResponse, LoginRequest, LoginResponse } from '@/services/authService'
+
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+export const mockLogin = async (payload: LoginRequest): Promise<LoginResponse> => {
+  await wait(350)
+
+  const stamp = Date.now()
+
+  return {
+    code: 200,
+    message: 'Login success',
+    data: {
+      accessToken: `mock-access-${payload.oauthProvider}-${stamp}`,
+      refreshToken: `mock-refresh-${stamp}`,
+    },
+  }
+}
+
+export const mockLogout = async (): Promise<BasicResponse> => {
+  await wait(150)
+
+  return {
+    code: 200,
+    message: 'Logout success',
+  }
+}

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -9,6 +9,7 @@ import MyPageView from '@/views/MyPageView/MyPageView.vue'
 import DietView from '@/views/DietView/DietView.vue'
 import DietRecordView from '@/views/DietView/DietRecordView.vue'
 import DietCafeteriaView from '@/views/DietView/DietCafeteriaView.vue'
+import { isAuthenticated } from '@/services/authService'
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -17,13 +18,13 @@ const router = createRouter({
       path: '/login',
       name: 'login',
       component: LoginView,
-      meta: { hideNav: true },
+      meta: { hideNav: true, guestOnly: true },
     },
     {
       path: '/regist', // 회원가입
       name: 'regist',
       component: SignupView,
-      meta: { hideNav: true },
+      meta: { hideNav: true, guestOnly: true },
     },
     {
       path: '/', // 메인페이지
@@ -39,23 +40,39 @@ const router = createRouter({
       path: '/mypage',
       name: 'mypage', // 마이페이지
       component: MyPageView,
+      meta: { requiresAuth: true },
     },
     {
       path: '/diet',
       name: 'diet', // 식단 페이지
       component: DietView,
+      meta: { requiresAuth: true },
     },
     {
       path: '/diet/record',
       name: 'diet-record',
       component: DietRecordView,
+      meta: { requiresAuth: true },
     },
     {
       path: '/diet/cafeteria',
       name: 'diet-cafeteria',
       component: DietCafeteriaView,
+      meta: { requiresAuth: true },
     },
   ],
+})
+
+router.beforeEach((to) => {
+  if (to.meta.requiresAuth && !isAuthenticated()) {
+    return { name: 'login', query: { redirect: to.fullPath } }
+  }
+
+  if (to.meta.guestOnly && isAuthenticated()) {
+    return { name: 'home' }
+  }
+
+  return true
 })
 
 export default router

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -1,0 +1,128 @@
+import { mockLogin, mockLogout } from '@/mocks/auth'
+
+export type OAuthProvider = 'KAKAO' | 'NAVER' | 'GOOGLE'
+
+export type LoginRequest = {
+  oauthProvider: OAuthProvider
+  oauthId: string
+  redirectUri: string
+}
+
+export type AuthTokens = {
+  accessToken: string
+  refreshToken: string
+}
+
+export type LoginResponse = {
+  code: number
+  message: string
+  data: AuthTokens
+}
+
+export type BasicResponse = {
+  code: number
+  message: string
+}
+
+const ACCESS_TOKEN_KEY = 'auth_access_token_v1'
+const REFRESH_TOKEN_KEY = 'auth_refresh_token_v1'
+const AUTH_MOCK_OVERRIDE = import.meta.env.VITE_AUTH_MOCK
+const SHOULD_USE_MOCK =
+  AUTH_MOCK_OVERRIDE === 'true'
+    ? true
+    : AUTH_MOCK_OVERRIDE === 'false'
+      ? false
+      : import.meta.env.VITE_API_MOCK !== 'false'
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? ''
+
+export const isAuthMockEnabled = () => SHOULD_USE_MOCK
+
+const storeTokens = (tokens: AuthTokens) => {
+  localStorage.setItem(ACCESS_TOKEN_KEY, tokens.accessToken)
+  localStorage.setItem(REFRESH_TOKEN_KEY, tokens.refreshToken)
+}
+
+export const clearTokens = () => {
+  localStorage.removeItem(ACCESS_TOKEN_KEY)
+  localStorage.removeItem(REFRESH_TOKEN_KEY)
+}
+
+export const getAccessToken = () => localStorage.getItem(ACCESS_TOKEN_KEY) ?? ''
+
+export const getRefreshToken = () => localStorage.getItem(REFRESH_TOKEN_KEY) ?? ''
+
+export const isAuthenticated = () => Boolean(getAccessToken())
+
+const parseJson = async <T>(response: Response, fallbackMessage: string) => {
+  const data = (await response
+    .json()
+    .catch(() => ({ code: response.status, message: fallbackMessage }))) as T
+  return data
+}
+
+export const login = async (payload: LoginRequest): Promise<LoginResponse> => {
+  if (SHOULD_USE_MOCK) {
+    const response = await mockLogin(payload)
+    storeTokens(response.data)
+    return response
+  }
+
+  if (!API_BASE_URL) {
+    throw new Error('API base URL is not configured.')
+  }
+
+  const response = await fetch(`${API_BASE_URL}/auth/login`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  })
+
+  const data = await parseJson<LoginResponse>(response, 'Login failed.')
+
+  if (!response.ok) {
+    throw new Error(data.message || 'Login failed.')
+  }
+
+  if (data.data?.accessToken) {
+    storeTokens(data.data)
+  }
+
+  return data
+}
+
+export const logout = async (): Promise<BasicResponse> => {
+  if (SHOULD_USE_MOCK) {
+    const response = await mockLogout()
+    clearTokens()
+    return response
+  }
+
+  if (!API_BASE_URL) {
+    clearTokens()
+    return { code: 200, message: 'Logged out locally.' }
+  }
+
+  const accessToken = getAccessToken()
+
+  try {
+    const response = await fetch(`${API_BASE_URL}/auth/logout`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: accessToken ? `Bearer ${accessToken}` : '',
+      },
+    })
+
+    const data = await parseJson<BasicResponse>(response, 'Logout failed.')
+
+    if (!response.ok) {
+      throw new Error(data.message || 'Logout failed.')
+    }
+
+    return data
+  } finally {
+    clearTokens()
+  }
+}

--- a/src/views/LoginView/LoginView.vue
+++ b/src/views/LoginView/LoginView.vue
@@ -1,10 +1,38 @@
 <script setup lang="ts">
-import { useRouter } from 'vue-router'
+import { ref } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { isAuthMockEnabled, login } from '@/services/authService'
+import type { OAuthProvider } from '@/services/authService'
 
 const router = useRouter()
+const route = useRoute()
+const isSubmitting = ref(false)
+const isMockMode = isAuthMockEnabled()
 
-const handleLogin = () => {
-  router.push('/') // TODO: replace with real auth flow
+const handleLogin = async (provider: OAuthProvider) => {
+  if (isSubmitting.value) {
+    return
+  }
+
+  isSubmitting.value = true
+
+  try {
+    await login({
+      oauthProvider: provider,
+      oauthId: `mock-${provider.toLowerCase()}-${Date.now()}`,
+      redirectUri: window.location.origin,
+    })
+
+    const redirectPath = typeof route.query.redirect === 'string' ? route.query.redirect : '/'
+    if (isMockMode) {
+      console.log('[Mock Login] success', { provider, redirectPath })
+    }
+    router.push(redirectPath)
+  } catch (error) {
+    console.error('Login failed:', error)
+  } finally {
+    isSubmitting.value = false
+  }
 }
 
 const handleSignup = () => {
@@ -47,7 +75,9 @@ const handleSignup = () => {
       <div class="space-y-3">
         <button
           type="button"
-          @click="handleLogin"
+          @click="handleLogin('KAKAO')"
+          :disabled="isSubmitting"
+          :aria-busy="isSubmitting"
           class="flex h-14 w-full items-center justify-center gap-2 rounded-xl bg-[#FEE500] text-[#000000] shadow-none transition hover:bg-[#FEE500]/90"
         >
           <svg
@@ -67,7 +97,9 @@ const handleSignup = () => {
 
         <button
           type="button"
-          @click="handleLogin"
+          @click="handleLogin('GOOGLE')"
+          :disabled="isSubmitting"
+          :aria-busy="isSubmitting"
           class="flex h-14 w-full items-center justify-center gap-2 rounded-xl border border-[var(--gray-300)] bg-white text-slate-900 shadow-none transition hover:bg-slate-50"
         >
           <svg
@@ -99,7 +131,9 @@ const handleSignup = () => {
 
         <button
           type="button"
-          @click="handleLogin"
+          @click="handleLogin('NAVER')"
+          :disabled="isSubmitting"
+          :aria-busy="isSubmitting"
           class="flex h-14 w-full items-center justify-center gap-2 rounded-xl bg-[#03C75A] text-white shadow-none transition hover:bg-[#03C75A]/90"
         >
           <svg

--- a/src/views/MyPageView/MyPageView.vue
+++ b/src/views/MyPageView/MyPageView.vue
@@ -17,6 +17,7 @@ import Dialog from '@/components/Dialog/Dialog.vue'
 import EditGoal from '@/views/MyPageView/EditGoal.vue'
 import EditProfile from '@/views/MyPageView/EditProfile.vue'
 import PrivacyPolicy from '@/views/MyPageView/PrivacyPolicy.vue'
+import { logout } from '@/services/authService'
 
 type SubPage = 'main' | 'edit-goal' | 'edit-profile' | 'privacy'
 
@@ -68,8 +69,14 @@ const handleSaveSubPage = () => {
   currentSubPage.value = 'main'
 }
 
-const handleLogout = () => {
-  router.push('/login')
+const handleLogout = async () => {
+  try {
+    await logout()
+  } catch (error) {
+    console.error('Logout failed:', error)
+  } finally {
+    router.push('/login')
+  }
 }
 
 const handleDeleteAccount = () => {


### PR DESCRIPTION
 ## <i>PULL REQUEST</i>
  ## feat: "Add mock auth flow and route guards"                                                                                            
                                                                                                                                            
  ### 🎋 작업중인 브랜치                                                                                                                    
  - feat/api                                                                                                                                
                                                                                                                                            
  ### 💡 작업동기                                                                                                                           
  - 백엔드 로그인 미완성 상태에서도 화면 개발을 막지 않기 위해 mock 기반 인증 스캐폴딩 필요.                                                
                                                                                                                                            
  ### 🔑 주요 변경사항                                                                                                                      
  - mock 로그인/로그아웃 서비스 및 토큰 저장 로직 추가                                                                                      
  - 라우트 가드(`requiresAuth`/`guestOnly`)로 인증 흐름 분리                                                                                
  - 로그인 버튼 동작 및 로그아웃 연동                                                                                                       
  - `.env*` gitignore 추가   