### PR TITLE
feat: "Add signup API wiring and axios auth client

### DIFF
--- a/docs/PROJECT_GUIDE.md
+++ b/docs/PROJECT_GUIDE.md
@@ -6,6 +6,7 @@
 
 - Vue 3 + TypeScript + Vite
 - Vue Router
+- axios (공통 API 래퍼 + 인터셉터)
 - Tailwind CSS + CSS 변수 기반 디자인 토큰
 - lucide-vue-next 아이콘
 - 패키지 매니저: pnpm
@@ -19,8 +20,12 @@
 - `src/views/`: 페이지 단위 화면
 - `src/components/`: 재사용 UI 컴포넌트
 - `src/composables/useDietStore.ts`: 식단 상태/로컬 스토리지 관리
-- `src/types/`: 도메인 타입 정의 (`diet.ts`)
-- `src/utils/`: 도메인 유틸리티 (`dietUtils.ts`)
+- `src/services/apiClient.ts`: axios 공통 래퍼(토큰 주입/리프레시)
+- `src/services/authService.ts`: 로그인/회원가입/닉네임/소속 API
+- `src/services/tokenStore.ts`: 토큰 저장/조회/삭제
+- `src/mocks/`: mock 응답(`auth.ts`)
+- `src/types/`: 도메인 타입(`diet.ts`, `signup.ts`, `axios.d.ts`)
+- `src/utils/`: 도메인 유틸(`dietUtils.ts`, `signupMapper.ts`)
 - `vite.config.ts`: `@` 경로 별칭 설정
 
 ## 라우팅 요약
@@ -50,8 +55,8 @@
 - `DietCafeteriaView`: 주간(월~금) 구내식당 메뉴 카드 리스트.
 - `CommunityView`: 전문가 칼럼 리스트, 카테고리/검색 필터.
 - `CommunityDetail`: 칼럼 상세 + 공유 모달 + 관련 글.
-- `LoginView`: 소셜 로그인 UI(동작은 더미 라우팅).
-- `SignupView`/`SignupFlow`: 다단계 회원가입 플로우, 목표/소속에 따라 단계 분기.
+- `LoginView`: 소셜 로그인 UI(현재 mock 로그인).
+- `SignupView`/`SignupFlow`: 다단계 회원가입, 닉네임 중복 체크 후 단건 전송.
 - `MyPageView`: 프로필 요약 + 하위 설정 페이지 전환.
 - `EditGoal`: 목표 수정 플로우(회원가입 스텝 재사용).
 - `EditProfile`: 개인정보 설정 폼.
@@ -67,6 +72,20 @@
 - `components/Diet/*`: 식단 관련 UI 카드/이미지/캘린더
 - `components/Home/*`: 홈 대시보드 카드/배너
 - `components/Signup/*`: 회원가입 각 단계
+
+## 인증/회원가입 흐름
+
+- 닉네임 중복 체크: `GET /user/nickname?nickname=...`
+- 소속 검색: `GET /user/groupSearch?keyword=...` (그룹 선택 시 `groupId` 전달)
+- 회원가입: `POST /auth/regist` (성공 시 토큰 저장 + 홈 이동)
+- 로그인: `POST /auth/login` (현재는 mock 유지)
+- 토큰 재발급: `POST /auth/refresh` (쿠키 refresh 기반, 401 시 자동 재시도)
+
+## 환경 변수
+
+- `VITE_API_BASE_URL`: API 베이스 URL
+- `VITE_API_MOCK`: 전체 mock 기본값 (`false`일 때만 실서버)
+- `VITE_AUTH_MOCK`: 로그인만 mock (`true` 우선 적용)
 
 ## 스타일/설정
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "prepare": "husky"
   },
   "dependencies": {
+    "axios": "^1.13.2",
     "lucide-vue-next": "^0.471.0",
     "vue": "^3.5.24",
     "vue-router": "^4.6.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      axios:
+        specifier: ^1.13.2
+        version: 1.13.2
       lucide-vue-next:
         specifier: ^0.471.0
         version: 0.471.0(vue@3.5.25(typescript@5.9.3))
@@ -473,12 +476,18 @@ packages:
   arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
 
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
   autoprefixer@10.4.22:
     resolution: {integrity: sha512-ARe0v/t9gO28Bznv6GgqARmVqcWOV3mfgUPn9becPHMiD3o9BwlRgaeccZnwTpZ7Zwqrm+c1sUSsMxIzQzc8Xg==}
     engines: {node: ^10 || ^12 || >=14}
     hasBin: true
     peerDependencies:
       postcss: ^8.1.0
+
+  axios@1.13.2:
+    resolution: {integrity: sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==}
 
   baseline-browser-mapping@2.9.4:
     resolution: {integrity: sha512-ZCQ9GEWl73BVm8bu5Fts8nt7MHdbt5vY9bP6WGnUh+r3l8M7CgfyTlwsgCbMC66BNxPr6Xoce3j66Ms5YUQTNA==}
@@ -496,6 +505,10 @@ packages:
     resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
 
   camelcase-css@2.0.1:
     resolution: {integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==}
@@ -519,6 +532,10 @@ packages:
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
 
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
   commander@14.0.2:
     resolution: {integrity: sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==}
     engines: {node: '>=20'}
@@ -535,11 +552,19 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
   didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
 
   dlv@1.1.3:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
+
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
 
   electron-to-chromium@1.5.266:
     resolution: {integrity: sha512-kgWEglXvkEfMH7rxP5OSZZwnaDWT7J9EoZCujhnpLbfi0bbNtRkgdX2E3gt0Uer11c61qCYktB3hwkAS325sJg==}
@@ -554,6 +579,22 @@ packages:
   environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
     engines: {node: '>=18'}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
 
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
@@ -590,6 +631,19 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
+  follow-redirects@1.15.11:
+    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+    engines: {node: '>= 6'}
+
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
 
@@ -605,6 +659,14 @@ packages:
     resolution: {integrity: sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==}
     engines: {node: '>=18'}
 
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
@@ -612,6 +674,18 @@ packages:
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
 
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
@@ -678,6 +752,10 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
@@ -685,6 +763,14 @@ packages:
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
 
   mimic-function@5.0.1:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
@@ -864,6 +950,9 @@ packages:
     resolution: {integrity: sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==}
     engines: {node: '>=14'}
     hasBin: true
+
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -1352,6 +1441,8 @@ snapshots:
 
   arg@5.0.2: {}
 
+  asynckit@0.4.0: {}
+
   autoprefixer@10.4.22(postcss@8.5.6):
     dependencies:
       browserslist: 4.28.1
@@ -1361,6 +1452,14 @@ snapshots:
       picocolors: 1.1.1
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
+
+  axios@1.13.2:
+    dependencies:
+      follow-redirects: 1.15.11
+      form-data: 4.0.5
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
 
   baseline-browser-mapping@2.9.4: {}
 
@@ -1377,6 +1476,11 @@ snapshots:
       electron-to-chromium: 1.5.266
       node-releases: 2.0.27
       update-browserslist-db: 1.2.2(browserslist@4.28.1)
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
 
   camelcase-css@2.0.1: {}
 
@@ -1405,6 +1509,10 @@ snapshots:
 
   colorette@2.0.20: {}
 
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
   commander@14.0.2: {}
 
   commander@4.1.1: {}
@@ -1413,9 +1521,17 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  delayed-stream@1.0.0: {}
+
   didyoumean@1.2.2: {}
 
   dlv@1.1.3: {}
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
 
   electron-to-chromium@1.5.266: {}
 
@@ -1424,6 +1540,21 @@ snapshots:
   entities@4.5.0: {}
 
   environment@1.1.0: {}
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.2
 
   esbuild@0.25.12:
     optionalDependencies:
@@ -1480,6 +1611,16 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
+  follow-redirects@1.15.11: {}
+
+  form-data@4.0.5:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
+      mime-types: 2.1.35
+
   fraction.js@5.3.4: {}
 
   fsevents@2.3.3:
@@ -1489,6 +1630,24 @@ snapshots:
 
   get-east-asian-width@1.4.0: {}
 
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.2
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
+
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
@@ -1496,6 +1655,14 @@ snapshots:
   glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
+
+  gopd@1.2.0: {}
+
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
 
   hasown@2.0.2:
     dependencies:
@@ -1564,12 +1731,20 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  math-intrinsics@1.1.0: {}
+
   merge2@1.4.1: {}
 
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
       picomatch: 2.3.1
+
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
 
   mimic-function@5.0.1: {}
 
@@ -1658,6 +1833,8 @@ snapshots:
       prettier: 3.7.4
 
   prettier@3.7.4: {}
+
+  proxy-from-env@1.1.0: {}
 
   queue-microtask@1.2.3: {}
 

--- a/src/components/Signup/SignupFlow.vue
+++ b/src/components/Signup/SignupFlow.vue
@@ -14,6 +14,7 @@ import StepNickname from './StepNickname.vue'
 import StepTargetWeight from './StepTargetWeight.vue'
 import StepTerms from './StepTerms.vue'
 import StepWelcome from './StepWelcome.vue'
+import type { FocusType, SignupResult } from '@/types/signup'
 
 type SignupStep =
   | 'nickname'
@@ -30,8 +31,6 @@ type SignupStep =
   | 'activityGoal'
   | 'targetWeight'
   | 'welcome'
-
-type FocusType = 'nutrition' | 'diet' | 'bulkup' | null
 
 const emit = defineEmits<{
   (e: 'complete', payload: SignupResult): void
@@ -55,26 +54,12 @@ const userInfo = ref({
 })
 const allergies = ref<string[]>([])
 const affiliationType = ref<'individual' | 'group'>('individual')
-const selectedAffiliation = ref('')
+const selectedAffiliation = ref<{ id: number; name: string } | null>(null)
 const diseases = ref<string[]>([])
 const habits = ref({ smoking: '', drinking: '' })
 const mealCount = ref('')
 const activityLevel = ref('')
 const targetWeight = ref('')
-
-export type SignupResult = {
-  nickname: string
-  terms: typeof termsAccepted.value
-  userInfo: typeof userInfo.value
-  allergies: string[]
-  affiliation: { type: typeof affiliationType.value; selected: string }
-  focusType: FocusType
-  diseases: string[]
-  habits: typeof habits.value
-  mealCount: string
-  activityLevel: string
-  targetWeight: string
-}
 
 const stepOrder = computed<SignupStep[]>(() => {
   const order: SignupStep[] = ['nickname', 'terms', 'info', 'allergies', 'affiliation']
@@ -141,10 +126,13 @@ const handleAllergiesNext = (values: string[]) => {
 
 const handleAffiliationNext = (type: 'individual' | 'group') => {
   affiliationType.value = type
+  if (type === 'individual') {
+    selectedAffiliation.value = null
+  }
   step.value = type === 'individual' ? 'focus' : 'affiliationSearch'
 }
 
-const handleAffiliationSearchNext = (affiliation: string) => {
+const handleAffiliationSearchNext = (affiliation: { id: number; name: string }) => {
   selectedAffiliation.value = affiliation
   step.value = 'focus'
 }
@@ -205,9 +193,6 @@ const handleWelcomeComplete = () => {
     activityLevel: activityLevel.value,
     targetWeight: targetWeight.value,
   } satisfies SignupResult
-
-  // API 연동 전까지 콘솔로 데이터 확인
-  console.log('[Signup] collected payload', payload)
 
   emit('complete', payload)
 }

--- a/src/components/Signup/StepAffiliationSearch.vue
+++ b/src/components/Signup/StepAffiliationSearch.vue
@@ -1,37 +1,64 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, ref, watch } from 'vue'
+import { searchGroups } from '@/services/authService'
 
 const emit = defineEmits<{
-  (e: 'next', affiliation: string): void
+  (e: 'next', affiliation: { id: number; name: string }): void
 }>()
 
-const affiliations = [
-  'SSAFY 12기',
-  '삼성전자',
-  'SK하이닉스',
-  'LG전자',
-  '네이버',
-  '카카오',
-  'LINE',
-  '쿠팡',
-  '배달의민족',
-  '토스',
-]
+type GroupOption = { groupId: number; groupName: string }
 
 const searchQuery = ref('')
-const selectedAffiliation = ref('')
+const results = ref<GroupOption[]>([])
+const selectedGroupId = ref<number | null>(null)
+const selectedGroupName = ref('')
+const isLoading = ref(false)
+const error = ref('')
+let debounceId: number | undefined
 
-const filteredAffiliations = computed(() =>
-  affiliations.filter((affiliation) =>
-    affiliation.toLowerCase().includes(searchQuery.value.toLowerCase()),
-  ),
-)
+const hasQuery = computed(() => Boolean(searchQuery.value.trim()))
+
+const handleSelect = (affiliation: GroupOption) => {
+  selectedGroupId.value = affiliation.groupId
+  selectedGroupName.value = affiliation.groupName
+}
 
 const handleSubmit = () => {
-  if (selectedAffiliation.value) {
-    emit('next', selectedAffiliation.value)
+  if (selectedGroupId.value !== null) {
+    emit('next', { id: selectedGroupId.value, name: selectedGroupName.value })
   }
 }
+
+watch(searchQuery, (value) => {
+  const query = value.trim()
+
+  if (debounceId) {
+    clearTimeout(debounceId)
+    debounceId = undefined
+  }
+
+  error.value = ''
+  selectedGroupId.value = null
+  selectedGroupName.value = ''
+
+  if (!query) {
+    results.value = []
+    return
+  }
+
+  debounceId = window.setTimeout(async () => {
+    isLoading.value = true
+    try {
+      results.value = await searchGroups(query)
+    } catch (err) {
+      console.error('Group search failed:', err)
+      error.value = '검색에 실패했습니다. 잠시 후 다시 시도해주세요'
+      results.value = []
+    } finally {
+      isLoading.value = false
+    }
+  }, 300)
+})
 </script>
 
 <template>
@@ -62,25 +89,39 @@ const handleSubmit = () => {
         />
       </div>
 
-      <div v-if="searchQuery" class="mt-6 space-y-2">
-        <template v-if="filteredAffiliations.length">
+      <div v-if="hasQuery" class="mt-6 space-y-2">
+        <div
+          v-if="isLoading"
+          class="py-6 text-center text-[14px] text-[var(--gray-400)]"
+          style="font-weight: 400"
+        >
+          검색 중...
+        </div>
+        <div
+          v-else-if="error"
+          class="py-6 text-center text-[14px] text-[var(--error-300)]"
+          style="font-weight: 400"
+        >
+          {{ error }}
+        </div>
+        <template v-else-if="results.length">
           <button
-            v-for="affiliation in filteredAffiliations"
-            :key="affiliation"
+            v-for="affiliation in results"
+            :key="affiliation.groupId"
             type="button"
-            @click="selectedAffiliation = affiliation"
+            @click="handleSelect(affiliation)"
             :class="[
               'w-full rounded-xl border-2 px-4 py-4 text-left text-[15px] transition-all active:scale-[0.98]',
-              selectedAffiliation === affiliation
+              selectedGroupId === affiliation.groupId
                 ? 'bg-[var(--gray-50)] text-[var(--gray-900)]'
                 : 'bg-[var(--gray-50)] text-[var(--gray-900)] hover:bg-[var(--gray-100)]',
             ]"
             :style="{
               fontWeight: 600,
-              borderColor: selectedAffiliation === affiliation ? '#00C73C' : 'var(--gray-300)',
+              borderColor: selectedGroupId === affiliation.groupId ? '#00C73C' : 'var(--gray-300)',
             }"
           >
-            {{ affiliation }}
+            {{ affiliation.groupName }}
           </button>
         </template>
         <div
@@ -95,17 +136,17 @@ const handleSubmit = () => {
 
     <button
       type="button"
-      :disabled="!selectedAffiliation"
+      :disabled="selectedGroupId === null"
       @click="handleSubmit"
       :class="[
         'h-[56px] w-full rounded-xl text-[16px] transition-all',
-        selectedAffiliation
+        selectedGroupId !== null
           ? 'text-white active:scale-[0.98]'
           : 'cursor-not-allowed bg-[var(--gray-100)] text-[var(--gray-400)]',
       ]"
       :style="{
         fontWeight: 600,
-        backgroundColor: selectedAffiliation ? '#00C73C' : undefined,
+        backgroundColor: selectedGroupId !== null ? '#00C73C' : undefined,
       }"
     >
       다음

--- a/src/components/Signup/StepNickname.vue
+++ b/src/components/Signup/StepNickname.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
+import { checkNickname } from '@/services/authService'
 
 const emit = defineEmits<{
   (e: 'next', nickname: string): void
@@ -8,6 +9,7 @@ const emit = defineEmits<{
 const nickname = ref('')
 const error = ref('')
 const hasAttempted = ref(false)
+const isChecking = ref(false)
 
 const validateNickname = (value: string): string => {
   if (!value) return '닉네임을 입력해주세요'
@@ -33,23 +35,41 @@ const isValid = computed(() => {
   return !validateNickname(nickname.value)
 })
 
-const handleSubmit = () => {
+const handleSubmit = async () => {
   hasAttempted.value = true
   const errorMsg = validateNickname(nickname.value)
 
-  if (!errorMsg) {
-    emit('next', nickname.value)
-  } else {
+  if (errorMsg) {
     error.value = errorMsg
+    return
+  }
+
+  if (isChecking.value) {
+    return
+  }
+
+  isChecking.value = true
+  try {
+    const response = await checkNickname(nickname.value)
+    if (response.code === 200) {
+      console.log('[Signup] nickname available', nickname.value)
+      emit('next', nickname.value)
+      return
+    }
+
+    error.value = response.message || '이미 사용 중인 닉네임입니다'
+  } catch (err) {
+    console.error('Nickname check failed:', err)
+    error.value = '닉네임 확인에 실패했습니다. 잠시 후 다시 시도해주세요'
+  } finally {
+    isChecking.value = false
   }
 }
 
 const handleInput = (value: string) => {
   nickname.value = value
-  if (hasAttempted.value) {
-    error.value = ''
-    hasAttempted.value = false
-  }
+  error.value = ''
+  hasAttempted.value = false
 }
 </script>
 
@@ -102,20 +122,20 @@ const handleInput = (value: string) => {
 
     <button
       type="button"
-      :disabled="!nickname"
+      :disabled="!nickname || isChecking"
       @click="handleSubmit"
       :class="[
         'h-[56px] w-full rounded-xl text-[16px] transition-all',
-        nickname
+        nickname && !isChecking
           ? 'text-white active:scale-[0.98]'
           : 'cursor-not-allowed bg-[var(--gray-100)] text-[var(--gray-400)]',
       ]"
       :style="{
         fontWeight: 600,
-        backgroundColor: nickname ? '#00C73C' : undefined,
+        backgroundColor: nickname && !isChecking ? '#00C73C' : undefined,
       }"
     >
-      다음
+      {{ isChecking ? '확인 중...' : '다음' }}
     </button>
   </div>
 </template>

--- a/src/mocks/auth.ts
+++ b/src/mocks/auth.ts
@@ -1,6 +1,35 @@
-import type { BasicResponse, LoginRequest, LoginResponse } from '@/services/authService'
+import type {
+  BasicResponse,
+  GroupSearchResponse,
+  LoginRequest,
+  LoginResponse,
+} from '@/services/authService'
 
 const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+const NICKNAME_STORAGE_KEY = 'mock_nicknames_v1'
+
+const getStoredNicknames = () => {
+  const raw = localStorage.getItem(NICKNAME_STORAGE_KEY)
+  if (!raw) {
+    return []
+  }
+
+  try {
+    const parsed = JSON.parse(raw)
+    return Array.isArray(parsed) ? parsed.filter((item) => typeof item === 'string') : []
+  } catch {
+    return []
+  }
+}
+
+const normalizeNickname = (value: string) => value.trim().toLowerCase()
+
+const MOCK_GROUPS = [
+  { groupId: 1, groupName: 'SSAFY Seoul Campus' },
+  { groupId: 2, groupName: 'SSAFY Daejeon Campus' },
+  { groupId: 3, groupName: 'SSAFY Gumi Campus' },
+  { groupId: 4, groupName: 'SSAFY Busan Campus' },
+]
 
 export const mockLogin = async (payload: LoginRequest): Promise<LoginResponse> => {
   await wait(350)
@@ -23,5 +52,46 @@ export const mockLogout = async (): Promise<BasicResponse> => {
   return {
     code: 200,
     message: 'Logout success',
+  }
+}
+
+export const mockCheckNickname = async (nickname: string): Promise<BasicResponse> => {
+  await wait(150)
+
+  const trimmed = nickname.trim()
+  if (!trimmed) {
+    return {
+      code: 400,
+      message: 'Invalid nickname.',
+    }
+  }
+
+  const storedNicknames = getStoredNicknames()
+  const normalized = normalizeNickname(trimmed)
+  const isDuplicate = storedNicknames.some((item) => normalizeNickname(item) === normalized)
+
+  if (isDuplicate) {
+    return {
+      code: 409,
+      message: 'Nickname already in use.',
+    }
+  }
+
+  return {
+    code: 200,
+    message: 'Nickname available.',
+  }
+}
+
+export const mockSearchGroups = async (keyword: string): Promise<GroupSearchResponse> => {
+  await wait(200)
+
+  const trimmed = keyword.trim().toLowerCase()
+  const matches = MOCK_GROUPS.filter((group) => group.groupName.toLowerCase().includes(trimmed))
+
+  return {
+    code: 200,
+    message: 'Group search success',
+    data: matches,
   }
 }

--- a/src/services/apiClient.ts
+++ b/src/services/apiClient.ts
@@ -1,0 +1,159 @@
+import axios, {
+  AxiosError,
+  AxiosHeaders,
+  type AxiosRequestConfig,
+  type AxiosResponse,
+  type InternalAxiosRequestConfig,
+} from 'axios'
+import { clearTokens, getAccessToken, setAccessToken } from '@/services/tokenStore'
+
+type ApiOptions = {
+  method?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'
+  withAuth?: boolean
+  headers?: Record<string, string>
+  body?: unknown
+  query?: Record<string, string | number | boolean>
+  acceptStatuses?: number[]
+  errorMessage?: string
+}
+
+type ApiErrorPayload = {
+  code?: number
+  message?: string
+}
+
+type RefreshResponse = {
+  code: number
+  message: string
+  data: {
+    accessToken: string
+  }
+}
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? ''
+
+const apiClient = axios.create({
+  baseURL: API_BASE_URL,
+  withCredentials: true,
+})
+
+const applyAuthHeader = (config: InternalAxiosRequestConfig, token: string) => {
+  if (!token) {
+    return
+  }
+
+  config.headers = AxiosHeaders.from(config.headers ?? {})
+  config.headers.set('Authorization', `Bearer ${token}`)
+}
+
+apiClient.interceptors.request.use((config: InternalAxiosRequestConfig) => {
+  if (config.withAuth) {
+    applyAuthHeader(config, getAccessToken())
+  }
+  return config
+})
+
+let refreshPromise: Promise<string> | null = null
+
+const refreshAccessToken = async () => {
+  const response = await apiClient.request<RefreshResponse, AxiosResponse<RefreshResponse>>({
+    url: '/auth/refresh',
+    method: 'POST',
+    withAuth: true,
+    skipAuthRefresh: true,
+  })
+
+  const accessToken = response.data?.data?.accessToken ?? ''
+  if (!accessToken) {
+    throw new Error('Token refresh failed.')
+  }
+
+  setAccessToken(accessToken)
+  return accessToken
+}
+
+apiClient.interceptors.response.use(
+  (response) => response,
+  async (error: AxiosError<ApiErrorPayload>) => {
+    const status = error.response?.status
+    const request = error.config as InternalAxiosRequestConfig | undefined
+
+    if (!request || status !== 401 || request.skipAuthRefresh || !request.withAuth) {
+      return Promise.reject(error)
+    }
+
+    if (request._retry) {
+      clearTokens()
+      return Promise.reject(error)
+    }
+
+    request._retry = true
+
+    try {
+      if (!refreshPromise) {
+        refreshPromise = refreshAccessToken()
+      }
+      const newToken = await refreshPromise
+      refreshPromise = null
+
+      applyAuthHeader(request, newToken)
+
+      return apiClient.request(request)
+    } catch (refreshError) {
+      refreshPromise = null
+      clearTokens()
+      return Promise.reject(refreshError)
+    }
+  },
+)
+
+export const apiFetch = async <T>(path: string, options: ApiOptions = {}): Promise<T> => {
+  if (!API_BASE_URL) {
+    throw new Error('API base URL is not configured.')
+  }
+
+  const {
+    method = 'GET',
+    withAuth = false,
+    headers = {},
+    body,
+    query,
+    acceptStatuses = [],
+    errorMessage = 'Request failed.',
+  } = options
+
+  const requestHeaders = new AxiosHeaders({
+    'Content-Type': 'application/json',
+    ...headers,
+  })
+
+  const config: AxiosRequestConfig = {
+    url: path,
+    method,
+    headers: requestHeaders,
+    params: query,
+    data: body,
+    withAuth,
+    validateStatus: (status) =>
+      Boolean(status && status >= 200 && status < 300) || acceptStatuses.includes(status ?? 0),
+  }
+
+  try {
+    const response = await apiClient.request<T, AxiosResponse<T>>(config)
+
+    if (response.status === 204 && acceptStatuses.includes(204)) {
+      return { code: 204, message: 'No Content', data: [] } as T
+    }
+
+    return response.data
+  } catch (err) {
+    if (axios.isAxiosError<ApiErrorPayload>(err)) {
+      const message =
+        err.response?.data?.message || err.message || errorMessage || 'Request failed.'
+      throw new Error(message)
+    }
+
+    const fallbackMessage = err instanceof Error ? err.message : errorMessage
+    throw new Error(fallbackMessage || errorMessage)
+  }
+}

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -1,5 +1,5 @@
 import { apiFetch } from '@/services/apiClient'
-import { mockLogin, mockLogout } from '@/mocks/auth'
+import { mockCheckNickname, mockLogin, mockLogout, mockSearchGroups } from '@/mocks/auth'
 import {
   clearTokens,
   getAccessToken,
@@ -33,22 +33,24 @@ export type BasicResponse = {
 }
 
 export type RegisterRequest = {
+  oauthProvider: OAuthProvider
+  oauthId: string
   nickname: string
-  isMarket: boolean
+  isMarketing: boolean
   gender: 'MALE' | 'FEMALE'
   height: number
   weight: number
   age: number
   allergies: string[]
-  Diseases: string[]
+  diseases: string[]
   status: 'SINGLE' | 'GROUP'
   groupId: number | null
   focus: 'HEALTHY' | 'DIET' | 'MUSCLE'
   isSmoking?: 'NONE' | 'SOMETIME' | 'OFTEN'
   isDrinking?: 'NONE' | 'SOMETIME' | 'OFTEN'
   meals?: 'ONE' | 'TWO' | 'THREE' | 'ETC'
-  activity_level?: 'LOW' | 'MEDIUM' | 'HIGH' | 'VERYHIGH'
-  target_weight?: number
+  activityLevel?: 'LOW' | 'MEDIUM' | 'HIGH' | 'VERYHIGH'
+  targetWeight?: number
 }
 
 export type GroupOption = {
@@ -111,6 +113,10 @@ export const logout = async (): Promise<BasicResponse> => {
 }
 
 export const checkNickname = async (nickname: string): Promise<BasicResponse> => {
+  if (SHOULD_USE_MOCK) {
+    return mockCheckNickname(nickname)
+  }
+
   return apiFetch<BasicResponse>('/user/nickname', {
     method: 'GET',
     withAuth: false,
@@ -124,6 +130,11 @@ export const searchGroups = async (keyword: string): Promise<GroupOption[]> => {
   const trimmed = keyword.trim()
   if (!trimmed) {
     return []
+  }
+
+  if (SHOULD_USE_MOCK) {
+    const data = await mockSearchGroups(trimmed)
+    return Array.isArray(data.data) ? data.data : []
   }
 
   const data = await apiFetch<GroupSearchResponse>('/user/groupSearch', {

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -1,4 +1,12 @@
+import { apiFetch } from '@/services/apiClient'
 import { mockLogin, mockLogout } from '@/mocks/auth'
+import {
+  clearTokens,
+  getAccessToken,
+  getRefreshToken,
+  isAuthenticated,
+  setTokens,
+} from '@/services/tokenStore'
 
 export type OAuthProvider = 'KAKAO' | 'NAVER' | 'GOOGLE'
 
@@ -24,8 +32,36 @@ export type BasicResponse = {
   message: string
 }
 
-const ACCESS_TOKEN_KEY = 'auth_access_token_v1'
-const REFRESH_TOKEN_KEY = 'auth_refresh_token_v1'
+export type RegisterRequest = {
+  nickname: string
+  isMarket: boolean
+  gender: 'MALE' | 'FEMALE'
+  height: number
+  weight: number
+  age: number
+  allergies: string[]
+  Diseases: string[]
+  status: 'SINGLE' | 'GROUP'
+  groupId: number | null
+  focus: 'HEALTHY' | 'DIET' | 'MUSCLE'
+  isSmoking?: 'NONE' | 'SOMETIME' | 'OFTEN'
+  isDrinking?: 'NONE' | 'SOMETIME' | 'OFTEN'
+  meals?: 'ONE' | 'TWO' | 'THREE' | 'ETC'
+  activity_level?: 'LOW' | 'MEDIUM' | 'HIGH' | 'VERYHIGH'
+  target_weight?: number
+}
+
+export type GroupOption = {
+  groupId: number
+  groupName: string
+}
+
+export type GroupSearchResponse = {
+  code: number
+  message: string
+  data: GroupOption[]
+}
+
 const AUTH_MOCK_OVERRIDE = import.meta.env.VITE_AUTH_MOCK
 const SHOULD_USE_MOCK =
   AUTH_MOCK_OVERRIDE === 'true'
@@ -33,62 +69,26 @@ const SHOULD_USE_MOCK =
     : AUTH_MOCK_OVERRIDE === 'false'
       ? false
       : import.meta.env.VITE_API_MOCK !== 'false'
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? ''
+
+export { clearTokens, getAccessToken, getRefreshToken, isAuthenticated }
 
 export const isAuthMockEnabled = () => SHOULD_USE_MOCK
-
-const storeTokens = (tokens: AuthTokens) => {
-  localStorage.setItem(ACCESS_TOKEN_KEY, tokens.accessToken)
-  localStorage.setItem(REFRESH_TOKEN_KEY, tokens.refreshToken)
-}
-
-export const clearTokens = () => {
-  localStorage.removeItem(ACCESS_TOKEN_KEY)
-  localStorage.removeItem(REFRESH_TOKEN_KEY)
-}
-
-export const getAccessToken = () => localStorage.getItem(ACCESS_TOKEN_KEY) ?? ''
-
-export const getRefreshToken = () => localStorage.getItem(REFRESH_TOKEN_KEY) ?? ''
-
-export const isAuthenticated = () => Boolean(getAccessToken())
-
-const parseJson = async <T>(response: Response, fallbackMessage: string) => {
-  const data = (await response
-    .json()
-    .catch(() => ({ code: response.status, message: fallbackMessage }))) as T
-  return data
-}
 
 export const login = async (payload: LoginRequest): Promise<LoginResponse> => {
   if (SHOULD_USE_MOCK) {
     const response = await mockLogin(payload)
-    storeTokens(response.data)
+    setTokens(response.data)
     return response
   }
 
-  if (!API_BASE_URL) {
-    throw new Error('API base URL is not configured.')
-  }
-
-  const response = await fetch(`${API_BASE_URL}/auth/login`, {
+  const data = await apiFetch<LoginResponse>('/auth/login', {
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify(payload),
+    withAuth: false,
+    body: payload,
+    errorMessage: 'Login failed.',
   })
 
-  const data = await parseJson<LoginResponse>(response, 'Login failed.')
-
-  if (!response.ok) {
-    throw new Error(data.message || 'Login failed.')
-  }
-
-  if (data.data?.accessToken) {
-    storeTokens(data.data)
-  }
-
+  setTokens(data.data)
   return data
 }
 
@@ -99,30 +99,52 @@ export const logout = async (): Promise<BasicResponse> => {
     return response
   }
 
-  if (!API_BASE_URL) {
-    clearTokens()
-    return { code: 200, message: 'Logged out locally.' }
-  }
-
-  const accessToken = getAccessToken()
-
   try {
-    const response = await fetch(`${API_BASE_URL}/auth/logout`, {
+    return await apiFetch<BasicResponse>('/auth/logout', {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: accessToken ? `Bearer ${accessToken}` : '',
-      },
+      withAuth: true,
+      errorMessage: 'Logout failed.',
     })
-
-    const data = await parseJson<BasicResponse>(response, 'Logout failed.')
-
-    if (!response.ok) {
-      throw new Error(data.message || 'Logout failed.')
-    }
-
-    return data
   } finally {
     clearTokens()
   }
+}
+
+export const checkNickname = async (nickname: string): Promise<BasicResponse> => {
+  return apiFetch<BasicResponse>('/user/nickname', {
+    method: 'GET',
+    withAuth: false,
+    query: { nickname },
+    acceptStatuses: [409],
+    errorMessage: 'Nickname check failed.',
+  })
+}
+
+export const searchGroups = async (keyword: string): Promise<GroupOption[]> => {
+  const trimmed = keyword.trim()
+  if (!trimmed) {
+    return []
+  }
+
+  const data = await apiFetch<GroupSearchResponse>('/user/groupSearch', {
+    method: 'GET',
+    withAuth: true,
+    query: { keyword: trimmed },
+    acceptStatuses: [204],
+    errorMessage: 'Group search failed.',
+  })
+
+  return Array.isArray(data.data) ? data.data : []
+}
+
+export const register = async (payload: RegisterRequest): Promise<LoginResponse> => {
+  const data = await apiFetch<LoginResponse>('/auth/regist', {
+    method: 'POST',
+    withAuth: false,
+    body: payload,
+    errorMessage: 'Signup failed.',
+  })
+
+  setTokens(data.data)
+  return data
 }

--- a/src/services/tokenStore.ts
+++ b/src/services/tokenStore.ts
@@ -1,0 +1,27 @@
+export type StoredTokens = {
+  accessToken: string
+  refreshToken: string
+}
+
+const ACCESS_TOKEN_KEY = 'auth_access_token_v1'
+const REFRESH_TOKEN_KEY = 'auth_refresh_token_v1'
+
+export const setTokens = (tokens: StoredTokens) => {
+  localStorage.setItem(ACCESS_TOKEN_KEY, tokens.accessToken)
+  localStorage.setItem(REFRESH_TOKEN_KEY, tokens.refreshToken)
+}
+
+export const setAccessToken = (accessToken: string) => {
+  localStorage.setItem(ACCESS_TOKEN_KEY, accessToken)
+}
+
+export const clearTokens = () => {
+  localStorage.removeItem(ACCESS_TOKEN_KEY)
+  localStorage.removeItem(REFRESH_TOKEN_KEY)
+}
+
+export const getAccessToken = () => localStorage.getItem(ACCESS_TOKEN_KEY) ?? ''
+
+export const getRefreshToken = () => localStorage.getItem(REFRESH_TOKEN_KEY) ?? ''
+
+export const isAuthenticated = () => Boolean(getAccessToken())

--- a/src/types/axios.d.ts
+++ b/src/types/axios.d.ts
@@ -1,0 +1,9 @@
+import 'axios'
+
+declare module 'axios' {
+  export interface AxiosRequestConfig {
+    withAuth?: boolean
+    skipAuthRefresh?: boolean
+    _retry?: boolean
+  }
+}

--- a/src/types/signup.ts
+++ b/src/types/signup.ts
@@ -1,0 +1,38 @@
+export type FocusType = 'nutrition' | 'diet' | 'bulkup' | null
+
+export type SignupTerms = {
+  service: boolean
+  privacy: boolean
+  marketing: boolean
+}
+
+export type SignupUserInfo = {
+  height: string
+  weight: string
+  age: string
+  gender: string
+}
+
+export type SignupHabits = {
+  smoking: string
+  drinking: string
+}
+
+export type SignupAffiliation = {
+  type: 'individual' | 'group'
+  selected: { id: number; name: string } | null
+}
+
+export type SignupResult = {
+  nickname: string
+  terms: SignupTerms
+  userInfo: SignupUserInfo
+  allergies: string[]
+  affiliation: SignupAffiliation
+  focusType: FocusType
+  diseases: string[]
+  habits: SignupHabits
+  mealCount: string
+  activityLevel: string
+  targetWeight: string
+}

--- a/src/utils/signupMapper.ts
+++ b/src/utils/signupMapper.ts
@@ -17,7 +17,7 @@ const mapMealCount = (count: string): RegisterRequest['meals'] => {
   return 'ETC'
 }
 
-const mapActivityLevel = (level: string): RegisterRequest['activity_level'] => {
+const mapActivityLevel = (level: string): RegisterRequest['activityLevel'] => {
   if (level === 'sedentary') return 'LOW'
   if (level === 'light') return 'MEDIUM'
   if (level === 'moderate') return 'HIGH'
@@ -39,14 +39,16 @@ export const buildRegisterPayload = (payload: SignupResult): RegisterRequest => 
   const cleanedDiseases = payload.diseases.includes('없음') ? [] : payload.diseases
 
   const result: RegisterRequest = {
+    oauthProvider: 'KAKAO',
+    oauthId: `mock-kakao-${Date.now()}`,
     nickname: payload.nickname,
-    isMarket: payload.terms.marketing,
+    isMarketing: payload.terms.marketing,
     gender: mapGender(payload.userInfo.gender),
     height: Number(payload.userInfo.height),
     weight: Number(payload.userInfo.weight),
     age: Number(payload.userInfo.age),
     allergies: payload.allergies,
-    Diseases: cleanedDiseases,
+    diseases: cleanedDiseases,
     status: payload.affiliation.type === 'group' ? 'GROUP' : 'SINGLE',
     groupId,
     focus,
@@ -57,7 +59,7 @@ export const buildRegisterPayload = (payload: SignupResult): RegisterRequest => 
   }
 
   if (payload.activityLevel) {
-    result.activity_level = mapActivityLevel(payload.activityLevel)
+    result.activityLevel = mapActivityLevel(payload.activityLevel)
   }
 
   if (focus === 'HEALTHY') {
@@ -66,7 +68,7 @@ export const buildRegisterPayload = (payload: SignupResult): RegisterRequest => 
   }
 
   if (focus !== 'HEALTHY' && payload.targetWeight) {
-    result.target_weight = Number(payload.targetWeight)
+    result.targetWeight = Number(payload.targetWeight)
   }
 
   return result

--- a/src/utils/signupMapper.ts
+++ b/src/utils/signupMapper.ts
@@ -1,0 +1,73 @@
+import type { RegisterRequest } from '@/services/authService'
+import type { SignupResult } from '@/types/signup'
+
+const mapGender = (gender: string): RegisterRequest['gender'] =>
+  gender === 'female' ? 'FEMALE' : 'MALE'
+
+const mapFocus = (focus: SignupResult['focusType']): RegisterRequest['focus'] => {
+  if (focus === 'diet') return 'DIET'
+  if (focus === 'bulkup') return 'MUSCLE'
+  return 'HEALTHY'
+}
+
+const mapMealCount = (count: string): RegisterRequest['meals'] => {
+  if (count === '1') return 'ONE'
+  if (count === '2') return 'TWO'
+  if (count === '3') return 'THREE'
+  return 'ETC'
+}
+
+const mapActivityLevel = (level: string): RegisterRequest['activity_level'] => {
+  if (level === 'sedentary') return 'LOW'
+  if (level === 'light') return 'MEDIUM'
+  if (level === 'moderate') return 'HIGH'
+  if (level === 'active') return 'HIGH'
+  return 'VERYHIGH'
+}
+
+const mapHabit = (value: string): RegisterRequest['isSmoking'] => {
+  if (value === 'none') return 'NONE'
+  if (value === 'light') return 'SOMETIME'
+  if (value === 'moderate') return 'SOMETIME'
+  return 'OFTEN'
+}
+
+export const buildRegisterPayload = (payload: SignupResult): RegisterRequest => {
+  const focus = mapFocus(payload.focusType)
+  const groupId =
+    payload.affiliation.type === 'group' ? (payload.affiliation.selected?.id ?? null) : null
+  const cleanedDiseases = payload.diseases.includes('없음') ? [] : payload.diseases
+
+  const result: RegisterRequest = {
+    nickname: payload.nickname,
+    isMarket: payload.terms.marketing,
+    gender: mapGender(payload.userInfo.gender),
+    height: Number(payload.userInfo.height),
+    weight: Number(payload.userInfo.weight),
+    age: Number(payload.userInfo.age),
+    allergies: payload.allergies,
+    Diseases: cleanedDiseases,
+    status: payload.affiliation.type === 'group' ? 'GROUP' : 'SINGLE',
+    groupId,
+    focus,
+  }
+
+  if (payload.mealCount) {
+    result.meals = mapMealCount(payload.mealCount)
+  }
+
+  if (payload.activityLevel) {
+    result.activity_level = mapActivityLevel(payload.activityLevel)
+  }
+
+  if (focus === 'HEALTHY') {
+    result.isSmoking = mapHabit(payload.habits.smoking)
+    result.isDrinking = mapHabit(payload.habits.drinking)
+  }
+
+  if (focus !== 'HEALTHY' && payload.targetWeight) {
+    result.target_weight = Number(payload.targetWeight)
+  }
+
+  return result
+}

--- a/src/views/SignupView/SignupView.vue
+++ b/src/views/SignupView/SignupView.vue
@@ -1,13 +1,34 @@
 <script setup lang="ts">
+import { ref } from 'vue'
 import { useRouter } from 'vue-router'
 import SignupFlow from '@/components/Signup/SignupFlow.vue'
-import type { SignupResult } from '@/components/Signup/SignupFlow.vue'
+import type { SignupResult } from '@/types/signup'
+import { register } from '@/services/authService'
+import { buildRegisterPayload } from '@/utils/signupMapper'
 
 const router = useRouter()
+const isSubmitting = ref(false)
 
-const handleComplete = (payload: SignupResult) => {
-  console.log('[Signup] complete payload', payload)
-  router.push('/')
+const handleComplete = async (payload: SignupResult) => {
+  if (isSubmitting.value) {
+    return
+  }
+
+  isSubmitting.value = true
+
+  try {
+    const request = buildRegisterPayload(payload)
+    console.log('[Signup] register request', request)
+    const response = await register(request)
+    console.log('[Signup] register response', response)
+    router.push('/')
+  } catch (error) {
+    console.error('Signup failed:', error)
+    alert('회원가입에 실패했습니다. 잠시 후 다시 시도해주세요.')
+    router.push('/login')
+  } finally {
+    isSubmitting.value = false
+  }
 }
 
 const handleExit = () => {


### PR DESCRIPTION
  ## <i>PULL REQUEST</i>                                                                                                                    
  ## feat: "Add signup API wiring and axios auth client"                                                                                    
                                                                                                                                            
  ### 🎋 작업중인 브랜치                                                                                                                    
  - feat/api                                                                                                                                
                                                                                                                                            
  ### 💡 작업동기                                                                                                                           
  - 회원가입 API 연동 및 공통 axios 클라이언트/토큰 재발급 흐름 정리.                                                                       
                                                                                                                                            
  ### 🔑 주요 변경사항                                                                                                                      
  - 회원가입: 닉네임 중복 체크/소속 검색/단건 전송 연동                                                                                     
  - 공통 API 클라이언트(axios) + 토큰 저장/리프레시 인터셉터 추가                                                                           
  - 타입/매핑/가이드 문서 정리         