### PR TITLE
feat: stabilize mock/real login flow and signup mappings

### DIFF
--- a/src/components/Signup/SignupFlow.vue
+++ b/src/components/Signup/SignupFlow.vue
@@ -73,7 +73,7 @@ const stepOrder = computed<SignupStep[]>(() => {
   if (focusType.value === 'nutrition') {
     order.push('disease', 'habits', 'mealCount', 'activity')
   } else if (focusType.value === 'diet' || focusType.value === 'bulkup') {
-    order.push('activityGoal', 'targetWeight')
+    order.push('mealCount', 'activityGoal', 'targetWeight')
   }
 
   order.push('welcome')
@@ -142,7 +142,7 @@ const handleFocusNext = (focus: FocusType) => {
   if (focus === 'nutrition') {
     step.value = 'disease'
   } else if (focus === 'diet' || focus === 'bulkup') {
-    step.value = 'activityGoal'
+    step.value = 'mealCount'
   }
 }
 
@@ -158,7 +158,11 @@ const handleHabitsNext = (values: typeof habits.value) => {
 
 const handleMealCountNext = (count: string) => {
   mealCount.value = count
-  step.value = 'activity'
+  if (focusType.value === 'nutrition') {
+    step.value = 'activity'
+    return
+  }
+  step.value = 'activityGoal'
 }
 
 const handleActivityNext = (level: string) => {

--- a/src/components/Signup/StepActivityLevel.vue
+++ b/src/components/Signup/StepActivityLevel.vue
@@ -6,11 +6,10 @@ const emit = defineEmits<{
 }>()
 
 const activityLevels = [
-  { value: 'sedentary', label: '거의 안함', desc: '주로 앉아서 생활' },
-  { value: 'light', label: '가벼운 활동', desc: '주 1-2회 가벼운 운동' },
-  { value: 'moderate', label: '보통 활동', desc: '주 3-4회 중강도 운동' },
-  { value: 'active', label: '활발한 활동', desc: '주 5-6회 고강도 운동' },
-  { value: 'very-active', label: '매우 활발', desc: '매일 고강도 운동' },
+  { value: 'low', label: '낮음', desc: '주로 앉아서 생활' },
+  { value: 'medium', label: '보통', desc: '가벼운 운동이나 활동 (주 1-3회)' },
+  { value: 'high', label: '높음', desc: '규칙적인 운동 (주 3-5회)' },
+  { value: 'veryhigh', label: '매우 높음', desc: '강도 높은 운동 (주 6-7회)' },
 ]
 
 const activityLevel = ref('')

--- a/src/components/Signup/StepAffiliationSearch.vue
+++ b/src/components/Signup/StepAffiliationSearch.vue
@@ -16,7 +16,12 @@ const isLoading = ref(false)
 const error = ref('')
 let debounceId: number | undefined
 
-const hasQuery = computed(() => Boolean(searchQuery.value.trim()))
+const trimmedQuery = computed(() => searchQuery.value.trim())
+const hasQuery = computed(() => Boolean(trimmedQuery.value))
+const isQueryTooShort = computed(() => hasQuery.value && trimmedQuery.value.length < 2)
+const helperMessage = computed(() =>
+  isQueryTooShort.value ? '검색어는 최소 2글자 이상이어야 합니다' : '',
+)
 
 const handleSelect = (affiliation: GroupOption) => {
   selectedGroupId.value = affiliation.groupId
@@ -46,10 +51,17 @@ watch(searchQuery, (value) => {
     return
   }
 
+  if (query.length < 2) {
+    results.value = []
+    return
+  }
+
   debounceId = window.setTimeout(async () => {
     isLoading.value = true
     try {
+      console.info('[Signup] group search query', query)
       results.value = await searchGroups(query)
+      console.info('[Signup] group search results', results.value)
     } catch (err) {
       console.error('Group search failed:', err)
       error.value = '검색에 실패했습니다. 잠시 후 다시 시도해주세요'
@@ -91,7 +103,14 @@ watch(searchQuery, (value) => {
 
       <div v-if="hasQuery" class="mt-6 space-y-2">
         <div
-          v-if="isLoading"
+          v-if="helperMessage"
+          class="py-4 text-center text-[14px] text-[var(--gray-500)]"
+          style="font-weight: 400"
+        >
+          {{ helperMessage }}
+        </div>
+        <div
+          v-else-if="isLoading"
           class="py-6 text-center text-[14px] text-[var(--gray-400)]"
           style="font-weight: 400"
         >

--- a/src/components/Signup/StepHabits.vue
+++ b/src/components/Signup/StepHabits.vue
@@ -7,16 +7,14 @@ const emit = defineEmits<{
 
 const smokingOptions = [
   { value: 'none', label: '비흡연' },
-  { value: 'light', label: '가끔' },
-  { value: 'moderate', label: '보통' },
-  { value: 'heavy', label: '자주' },
+  { value: 'sometime', label: '가끔' },
+  { value: 'often', label: '자주' },
 ]
 
 const drinkingOptions = [
   { value: 'none', label: '음주 안함' },
-  { value: 'light', label: '가끔 (월 1-2회)' },
-  { value: 'moderate', label: '보통 (주 1-2회)' },
-  { value: 'heavy', label: '자주 (주 3회 이상)' },
+  { value: 'sometime', label: '가끔' },
+  { value: 'often', label: '자주' },
 ]
 
 const smoking = ref('')

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -69,6 +69,10 @@ router.beforeEach((to) => {
   }
 
   if (to.meta.guestOnly && isAuthenticated()) {
+    if (import.meta.env.DEV) {
+      // TODO: remove dev override once auth flow is finalized.
+      return true
+    }
     return { name: 'home' }
   }
 

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -1,10 +1,13 @@
 import { apiFetch } from '@/services/apiClient'
 import { mockCheckNickname, mockLogin, mockLogout, mockSearchGroups } from '@/mocks/auth'
 import {
+  clearAuthMode,
   clearTokens,
   getAccessToken,
+  getAuthMode,
   getRefreshToken,
   isAuthenticated,
+  setAuthMode,
   setTokens,
 } from '@/services/tokenStore'
 
@@ -76,10 +79,20 @@ export { clearTokens, getAccessToken, getRefreshToken, isAuthenticated }
 
 export const isAuthMockEnabled = () => SHOULD_USE_MOCK
 
-export const login = async (payload: LoginRequest): Promise<LoginResponse> => {
-  if (SHOULD_USE_MOCK) {
+const shouldUseMockAuth = () => SHOULD_USE_MOCK && getAuthMode() !== 'real'
+
+type LoginOptions = {
+  forceReal?: boolean
+}
+
+export const login = async (
+  payload: LoginRequest,
+  options: LoginOptions = {},
+): Promise<LoginResponse> => {
+  if (!options.forceReal && SHOULD_USE_MOCK) {
     const response = await mockLogin(payload)
     setTokens(response.data)
+    setAuthMode('mock')
     return response
   }
 
@@ -91,13 +104,16 @@ export const login = async (payload: LoginRequest): Promise<LoginResponse> => {
   })
 
   setTokens(data.data)
+  setAuthMode('real')
   return data
 }
 
 export const logout = async (): Promise<BasicResponse> => {
-  if (SHOULD_USE_MOCK) {
+  const useMock = shouldUseMockAuth()
+  if (useMock) {
     const response = await mockLogout()
     clearTokens()
+    clearAuthMode()
     return response
   }
 
@@ -109,17 +125,18 @@ export const logout = async (): Promise<BasicResponse> => {
     })
   } finally {
     clearTokens()
+    clearAuthMode()
   }
 }
 
 export const checkNickname = async (nickname: string): Promise<BasicResponse> => {
-  if (SHOULD_USE_MOCK) {
+  if (shouldUseMockAuth()) {
     return mockCheckNickname(nickname)
   }
 
   return apiFetch<BasicResponse>('/user/nickname', {
     method: 'GET',
-    withAuth: false,
+    withAuth: true,
     query: { nickname },
     acceptStatuses: [409],
     errorMessage: 'Nickname check failed.',
@@ -132,7 +149,7 @@ export const searchGroups = async (keyword: string): Promise<GroupOption[]> => {
     return []
   }
 
-  if (SHOULD_USE_MOCK) {
+  if (shouldUseMockAuth()) {
     const data = await mockSearchGroups(trimmed)
     return Array.isArray(data.data) ? data.data : []
   }

--- a/src/services/oauthStore.ts
+++ b/src/services/oauthStore.ts
@@ -1,0 +1,28 @@
+import type { OAuthProvider } from '@/services/authService'
+
+const OAUTH_ID_PREFIX = 'mock_oauth_id_v1_'
+
+const buildKey = (provider: OAuthProvider) => `${OAUTH_ID_PREFIX}${provider.toLowerCase()}`
+
+export const getStoredOAuthId = (provider: OAuthProvider) => {
+  return localStorage.getItem(buildKey(provider)) ?? ''
+}
+
+export const setStoredOAuthId = (provider: OAuthProvider, oauthId: string) => {
+  localStorage.setItem(buildKey(provider), oauthId)
+}
+
+export const getOrCreateOAuthId = (provider: OAuthProvider) => {
+  const stored = getStoredOAuthId(provider)
+  if (stored) {
+    return stored
+  }
+
+  const generated = `mock-${provider.toLowerCase()}-${Date.now()}`
+  setStoredOAuthId(provider, generated)
+  return generated
+}
+
+export const clearStoredOAuthId = (provider: OAuthProvider) => {
+  localStorage.removeItem(buildKey(provider))
+}

--- a/src/services/tokenStore.ts
+++ b/src/services/tokenStore.ts
@@ -3,8 +3,11 @@ export type StoredTokens = {
   refreshToken: string
 }
 
+export type AuthMode = 'mock' | 'real'
+
 const ACCESS_TOKEN_KEY = 'auth_access_token_v1'
 const REFRESH_TOKEN_KEY = 'auth_refresh_token_v1'
+const AUTH_MODE_KEY = 'auth_mode_v1'
 
 export const setTokens = (tokens: StoredTokens) => {
   localStorage.setItem(ACCESS_TOKEN_KEY, tokens.accessToken)
@@ -25,3 +28,16 @@ export const getAccessToken = () => localStorage.getItem(ACCESS_TOKEN_KEY) ?? ''
 export const getRefreshToken = () => localStorage.getItem(REFRESH_TOKEN_KEY) ?? ''
 
 export const isAuthenticated = () => Boolean(getAccessToken())
+
+export const setAuthMode = (mode: AuthMode) => {
+  localStorage.setItem(AUTH_MODE_KEY, mode)
+}
+
+export const getAuthMode = (): AuthMode | '' => {
+  const value = localStorage.getItem(AUTH_MODE_KEY)
+  return value === 'mock' || value === 'real' ? value : ''
+}
+
+export const clearAuthMode = () => {
+  localStorage.removeItem(AUTH_MODE_KEY)
+}

--- a/src/utils/signupMapper.ts
+++ b/src/utils/signupMapper.ts
@@ -1,4 +1,5 @@
 import type { RegisterRequest } from '@/services/authService'
+import { getOrCreateOAuthId } from '@/services/oauthStore'
 import type { SignupResult } from '@/types/signup'
 
 const mapGender = (gender: string): RegisterRequest['gender'] =>
@@ -18,10 +19,9 @@ const mapMealCount = (count: string): RegisterRequest['meals'] => {
 }
 
 const mapActivityLevel = (level: string): RegisterRequest['activityLevel'] => {
-  if (level === 'sedentary') return 'LOW'
-  if (level === 'light') return 'MEDIUM'
-  if (level === 'moderate') return 'HIGH'
-  if (level === 'active') return 'HIGH'
+  if (level === 'low' || level === 'sedentary') return 'LOW'
+  if (level === 'medium' || level === 'light') return 'MEDIUM'
+  if (level === 'high' || level === 'moderate' || level === 'active') return 'HIGH'
   return 'VERYHIGH'
 }
 
@@ -29,6 +29,8 @@ const mapHabit = (value: string): RegisterRequest['isSmoking'] => {
   if (value === 'none') return 'NONE'
   if (value === 'light') return 'SOMETIME'
   if (value === 'moderate') return 'SOMETIME'
+  if (value === 'sometime') return 'SOMETIME'
+  if (value === 'often') return 'OFTEN'
   return 'OFTEN'
 }
 
@@ -40,7 +42,7 @@ export const buildRegisterPayload = (payload: SignupResult): RegisterRequest => 
 
   const result: RegisterRequest = {
     oauthProvider: 'KAKAO',
-    oauthId: `mock-kakao-${Date.now()}`,
+    oauthId: getOrCreateOAuthId('KAKAO'),
     nickname: payload.nickname,
     isMarketing: payload.terms.marketing,
     gender: mapGender(payload.userInfo.gender),

--- a/src/views/LoginView/LoginView.vue
+++ b/src/views/LoginView/LoginView.vue
@@ -2,12 +2,20 @@
 import { ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { isAuthMockEnabled, login } from '@/services/authService'
+import {
+  clearStoredOAuthId,
+  getOrCreateOAuthId,
+  getStoredOAuthId,
+  setStoredOAuthId,
+} from '@/services/oauthStore'
 import type { OAuthProvider } from '@/services/authService'
 
 const router = useRouter()
 const route = useRoute()
 const isSubmitting = ref(false)
 const isMockMode = isAuthMockEnabled()
+const isDev = import.meta.env.DEV
+const testOauthId = ref(getStoredOAuthId('KAKAO'))
 
 const handleLogin = async (provider: OAuthProvider) => {
   if (isSubmitting.value) {
@@ -16,17 +24,25 @@ const handleLogin = async (provider: OAuthProvider) => {
 
   isSubmitting.value = true
 
+  const shouldForceReal = provider === 'KAKAO'
+  const shouldUseMock = isMockMode && !shouldForceReal
+
   try {
-    await login({
-      oauthProvider: provider,
-      oauthId: `mock-${provider.toLowerCase()}-${Date.now()}`,
-      redirectUri: window.location.origin,
-    })
+    console.info(`[Login] ${shouldUseMock ? 'mock' : 'real'} login start`, { provider })
+    await login(
+      {
+        oauthProvider: provider,
+        oauthId: getOrCreateOAuthId(provider),
+        redirectUri: window.location.origin,
+      },
+      { forceReal: shouldForceReal },
+    )
 
     const redirectPath = typeof route.query.redirect === 'string' ? route.query.redirect : '/'
-    if (isMockMode) {
-      console.log('[Mock Login] success', { provider, redirectPath })
-    }
+    console.info(`[Login] ${shouldUseMock ? 'mock' : 'real'} login success`, {
+      provider,
+      redirectPath,
+    })
     router.push(redirectPath)
   } catch (error) {
     console.error('Login failed:', error)
@@ -37,6 +53,22 @@ const handleLogin = async (provider: OAuthProvider) => {
 
 const handleSignup = () => {
   router.push('/regist')
+}
+
+const handleApplyTestOauthId = () => {
+  const trimmed = testOauthId.value.trim()
+  if (!trimmed) {
+    return
+  }
+
+  setStoredOAuthId('KAKAO', trimmed)
+  console.info('[Login] test oauthId applied', { provider: 'KAKAO', oauthId: trimmed })
+}
+
+const handleClearTestOauthId = () => {
+  clearStoredOAuthId('KAKAO')
+  testOauthId.value = ''
+  console.info('[Login] test oauthId cleared', { provider: 'KAKAO' })
 }
 </script>
 
@@ -147,6 +179,40 @@ const handleSignup = () => {
           </svg>
           <span>네이버 로그인</span>
         </button>
+      </div>
+
+      <div
+        v-if="isDev"
+        class="mt-8 rounded-2xl border border-[var(--gray-200)] bg-[var(--gray-50)] p-4 text-[13px] text-[var(--gray-700)]"
+      >
+        <p class="mb-3" style="font-weight: 600">테스트 로그인 설정 (KAKAO)</p>
+        <p class="mb-3 text-[12px] text-[var(--gray-500)]" style="font-weight: 400">
+          DB에 있는 oauth_id 값을 입력하면 해당 계정으로 로그인됩니다.
+        </p>
+        <div class="flex items-center gap-2">
+          <input
+            v-model="testOauthId"
+            type="text"
+            placeholder="mock-kakao-..."
+            class="h-10 flex-1 rounded-lg border border-[var(--gray-300)] bg-white px-3 text-[13px] focus:outline-none focus:ring-1 focus:ring-[#00C73C]"
+          />
+          <button
+            type="button"
+            @click="handleApplyTestOauthId"
+            class="h-10 rounded-lg bg-[#00C73C] px-3 text-white"
+            style="font-weight: 600"
+          >
+            적용
+          </button>
+          <button
+            type="button"
+            @click="handleClearTestOauthId"
+            class="h-10 rounded-lg border border-[var(--gray-300)] bg-white px-3 text-[var(--gray-700)]"
+            style="font-weight: 600"
+          >
+            초기화
+          </button>
+        </div>
       </div>
 
       <div class="pt-8 text-center">


### PR DESCRIPTION
 ## <i>PULL REQUEST</i>                                                                                                 
                                                                                                                         
  ## feat: "Stabilize signup/login flow"        // 타입: 제목                                                            
                                                                                                                         
  ### 🎋 작업중인 브랜치                                                                                                 
                                                                                                                         
  - feat/api                                                                                                             
                                                                                                                         
  ### 💡 작업동기                                                                                                        
                                                                                                                         
  - 로그인 미구현/토큰 부재 환경에서 회원가입 플로우 테스트가 막혀 있어, mock/real 전환과 필드 매핑을 안정화하고자 했습니    다.                                                                                                                  
                                                                                                                         
  ### 🔑 주요 변경사항                                                                                                   
                                                                                                                         
  - 회원가입 요청 필드명 정합성(isMarketing, diseases, activityLevel, targetWeight) 맞춤                                 
  - 카카오 로그인은 실서버 호출, oauthId 재사용 저장으로 테스트 계정 고정 가능                                           
  - 닉네임/소속 검색은 로그인 성공 시 인증 헤더 사용, mock 모드 분기 유지                                                
  - diet/bulkup 플로우에 식사 횟수 단계 추가                                                                             
  - 흡연/음주, 활동량 선택지를 API 스펙(3단계/4단계)에 맞춰 조정                                                         
  - DEV 환경에서 guestOnly 라우팅 우회 (테스트용) 