### PR TITLE
Refactor/last

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>meow_punch_frontend</title>
   </head>

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,36 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="64"
+  height="64"
+  viewBox="0 0 24 24"
+  role="img"
+  aria-label="Picket logo"
+>
+  <rect width="24" height="24" rx="6" fill="#00c73c" />
+  <g transform="translate(12 12) scale(0.8) translate(-12 -12)">
+    <path
+      d="M3 2v7c0 1.1.9 2 2 2h4a2 2 0 0 0 2-2V2"
+      fill="none"
+      stroke="#fff"
+      stroke-width="2.5"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
+    <path
+      d="M7 2v20"
+      fill="none"
+      stroke="#fff"
+      stroke-width="2.5"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
+    <path
+      d="M21 15V2a5 5 0 0 0-5 5v6c0 1.1.9 2 2 2h3Zm0 0v7"
+      fill="none"
+      stroke="#fff"
+      stroke-width="2.5"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
+  </g>
+</svg>

--- a/src/components/Diet/CafeteriaMenuCard.vue
+++ b/src/components/Diet/CafeteriaMenuCard.vue
@@ -7,7 +7,9 @@ type CafeteriaMenuItem = {
   main: string
   sub: string
   kcal: number
+  carbs?: number
   protein?: number
+  fat?: number
   soldout?: boolean
   image?: string | null
 }
@@ -49,9 +51,18 @@ defineProps<{
         <span class="text-[13px] font-bold text-[var(--gray-800)]">
           {{ menu.kcal }} <span class="text-[11px] font-normal text-[var(--gray-500)]">kcal</span>
         </span>
-        <span v-if="menu.protein !== undefined" class="h-3 w-px bg-[var(--gray-200)]" />
+        <span
+          v-if="menu.carbs !== undefined || menu.protein !== undefined || menu.fat !== undefined"
+          class="h-3 w-px bg-[var(--gray-200)]"
+        />
+        <span v-if="menu.carbs !== undefined" class="text-[12px] text-[var(--gray-500)]">
+          탄 {{ menu.carbs }}g
+        </span>
         <span v-if="menu.protein !== undefined" class="text-[12px] text-[var(--gray-500)]">
-          단백질 {{ menu.protein }}g
+          단 {{ menu.protein }}g
+        </span>
+        <span v-if="menu.fat !== undefined" class="text-[12px] text-[var(--gray-500)]">
+          지 {{ menu.fat }}g
         </span>
       </div>
     </div>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -9,6 +9,7 @@ import DietView from '@/views/DietView/DietView.vue'
 import DietRecordView from '@/views/DietView/DietRecordView.vue'
 import DietCafeteriaView from '@/views/DietView/DietCafeteriaView.vue'
 import { isAuthenticated } from '@/services/authService'
+import { getRegisterToken } from '@/services/registerTokenStore'
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -69,11 +70,15 @@ const router = createRouter({
 })
 
 router.beforeEach((to) => {
-  if (to.meta.requiresAuth && !isAuthenticated()) {
+  const authenticated = isAuthenticated()
+  const registerToken = getRegisterToken()
+  const isRegisterFlow = to.name === 'regist' && Boolean(registerToken)
+
+  if (!authenticated && to.name !== 'login' && to.name !== 'oauth-callback' && !isRegisterFlow) {
     return { name: 'login', query: { redirect: to.fullPath } }
   }
 
-  if (to.meta.guestOnly && isAuthenticated()) {
+  if (to.meta.guestOnly && authenticated) {
     if (import.meta.env.DEV) {
       // TODO: remove dev override once auth flow is finalized.
       return true

--- a/src/services/registerTokenStore.ts
+++ b/src/services/registerTokenStore.ts
@@ -1,0 +1,17 @@
+const REGISTER_TOKEN_KEY = 'register_token_v1'
+
+export const setRegisterToken = (token: string) => {
+  if (!token) {
+    sessionStorage.removeItem(REGISTER_TOKEN_KEY)
+    return
+  }
+  sessionStorage.setItem(REGISTER_TOKEN_KEY, token)
+}
+
+export const getRegisterToken = () => {
+  return sessionStorage.getItem(REGISTER_TOKEN_KEY) ?? ''
+}
+
+export const clearRegisterToken = () => {
+  sessionStorage.removeItem(REGISTER_TOKEN_KEY)
+}

--- a/src/views/DietView/DietCafeteriaView.vue
+++ b/src/views/DietView/DietCafeteriaView.vue
@@ -47,7 +47,9 @@ const mapSlotMenus = (slot: keyof typeof slotTime) =>
     main: menu.name,
     sub: menu.subName,
     kcal: menu.calorie,
+    carbs: menu.nutrients?.carbs,
     protein: menu.nutrients?.protein,
+    fat: menu.nutrients?.fat,
     soldout: false,
     image: resolveDietImageUrl(menu.thumbnailUrls?.[0]),
   }))

--- a/src/views/HomeView/HomeView.vue
+++ b/src/views/HomeView/HomeView.vue
@@ -68,16 +68,14 @@ const banners: Banner[] = [
   },
 ]
 
-const totalCalories = ref(1850)
-const targetCalories = ref(2000)
-const aiMessage = ref(
-  '단백질 섭취가 목표보다 25g 부족해요. 저녁에 고단백 저지방 식품을 추가해보세요.',
-)
+const totalCalories = ref(0)
+const targetCalories = ref(0)
+const aiMessage = ref('')
 
 const nutritionData = ref<NutritionItem[]>([
-  { name: '탄수화물', current: 250, target: 280 },
-  { name: '단백질', current: 95, target: 120 },
-  { name: '지방', current: 82, target: 70 },
+  { name: '탄수화물', current: 0, target: 0 },
+  { name: '단백질', current: 0, target: 0 },
+  { name: '지방', current: 0, target: 0 },
 ])
 
 const recommendedMeals = ref<RecommendedMeal[]>([])
@@ -85,9 +83,9 @@ const weeklyAverageCalories = ref('0kcal')
 const weeklyAchievement = ref('0%')
 const weeklyStreak = ref('0일')
 const menuCardLabel = ref('메뉴 보러가기')
-const menuCardSubtitle = ref('오늘 우리 회사 메뉴는 무엇일까요?')
+const menuCardSubtitle = ref('오늘 등록된 메뉴가 없습니다.')
 const menuCardChip = ref('NEW')
-const menuCardFooter = ref('SSAFY 14기 · 23명')
+const menuCardFooter = ref('소속 미지정')
 
 const mealTypeLabels: Record<DietMealType, string> = {
   BREAKFAST: '아침',

--- a/src/views/LoginView/LoginView.vue
+++ b/src/views/LoginView/LoginView.vue
@@ -1,9 +1,7 @@
 <script setup lang="ts">
 import { ref } from 'vue'
-import { useRouter } from 'vue-router'
 import type { OAuthProvider } from '@/services/authService'
 
-const router = useRouter()
 const isSubmitting = ref(false)
 
 const handleLogin = async (provider: OAuthProvider) => {
@@ -30,10 +28,6 @@ const handleLogin = async (provider: OAuthProvider) => {
 
   // TODO: 구글/네이버 로그인 구현 예정
   alert('준비 중인 기능입니다.')
-}
-
-const handleSignup = () => {
-  router.push('/regist')
 }
 </script>
 
@@ -144,19 +138,6 @@ const handleSignup = () => {
           </svg>
           <span>네이버 로그인</span>
         </button>
-      </div>
-
-      <div class="pt-8 text-center">
-        <p class="text-muted-foreground">
-          계정이 없으신가요?
-          <button
-            type="button"
-            @click="handleSignup"
-            class="text-[var(--main-300)] transition hover:underline"
-          >
-            회원가입
-          </button>
-        </p>
       </div>
     </div>
   </div>

--- a/src/views/LoginView/OAuthCallback.vue
+++ b/src/views/LoginView/OAuthCallback.vue
@@ -2,6 +2,7 @@
 import { onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { login, type OAuthProvider } from '@/services/authService'
+import { setRegisterToken } from '@/services/registerTokenStore'
 
 const route = useRoute()
 const router = useRouter()
@@ -34,11 +35,8 @@ onMounted(async () => {
       router.replace('/')
     } else if (result.status === 'NEED_REGISTER') {
       console.log('[OAuthCallback] Need registration', result.data)
-      // 회원가입 페이지로 이동하며 registerToken을 state로 전달
-      router.replace({
-        path: '/regist',
-        state: { registerToken: result.data.registerToken },
-      })
+      setRegisterToken(result.data.registerToken)
+      router.replace('/regist')
     }
   } catch (error) {
     console.error('[OAuthCallback] Login failed', error)

--- a/src/views/MyPageView/EditProfile.vue
+++ b/src/views/MyPageView/EditProfile.vue
@@ -277,7 +277,7 @@ const handleSave = async () => {
                 <input
                   id="group"
                   v-model="formData.group"
-                  placeholder="예: SSAFY 12기, OO 대학교"
+                  placeholder="예: 전기부산, 멀티캠퍼스"
                   class="h-11 w-full rounded-lg border border-[var(--gray-300)] px-3 pr-9 text-[14px] text-[var(--gray-900)] outline-none transition focus:border-[#00C73C]"
                   readonly
                 />

--- a/src/views/MyPageView/MyPageView.vue
+++ b/src/views/MyPageView/MyPageView.vue
@@ -26,7 +26,6 @@ const nickname = ref('건강한하루')
 const tempNickname = ref(nickname.value)
 const isEditingNickname = ref(false)
 const currentSubPage = ref<SubPage>('main')
-const progressPercentOverride = ref<number | null>(null)
 const isDev = import.meta.env.DEV
 
 const userInfo = reactive({
@@ -60,17 +59,6 @@ const mapGenderLabel = (gender: string) => (gender === 'MALE' ? '남성' : '여�
 const isWeightFocused = computed(
   () => userInfo.userType === '다이어트' || userInfo.userType === '체중증량',
 )
-const weightChange = computed(() => userInfo.currentWeight - userInfo.startWeight)
-const progressPercentage = computed(() => {
-  if (progressPercentOverride.value !== null) {
-    return progressPercentOverride.value
-  }
-  const denominator = userInfo.startWeight - userInfo.targetWeight
-  if (!denominator) {
-    return 0
-  }
-  return ((userInfo.startWeight - userInfo.currentWeight) / denominator) * 100
-})
 const weeklyMealRate = computed(() => {
   if (!userInfo.thisWeekTargetMealCount) {
     return 0
@@ -400,35 +388,17 @@ onMounted(loadUserProfile)
               <div class="mb-2 flex items-center gap-2">
                 <Scale class="h-4 w-4 text-[#00C73C]" />
                 <span class="text-[13px] text-[var(--gray-600)]" style="font-weight: 500">
-                  시작 체중
+                  체중
                 </span>
               </div>
               <p class="text-[24px] text-[var(--gray-900)]" style="font-weight: 700">
-                {{ userInfo.startWeight }}
+                {{ userInfo.currentWeight }}
                 <span class="ml-1 text-[14px] text-[var(--gray-600)]" style="font-weight: 400">
                   kg
                 </span>
               </p>
               <p class="mt-1 text-[12px] text-[var(--gray-500)]" style="font-weight: 400">
                 목표 {{ userInfo.targetWeight }}kg
-              </p>
-            </div>
-
-            <div>
-              <div class="mb-2 flex items-center gap-2">
-                <TrendingDown class="h-4 w-4 text-[#00C73C]" />
-                <span class="text-[13px] text-[var(--gray-600)]" style="font-weight: 500">
-                  체중 변화
-                </span>
-              </div>
-              <p class="text-[24px]" style="font-weight: 700; color: #00c73c">
-                {{ weightChange >= 0 ? '+' : '' }}{{ weightChange.toFixed(1) }}
-                <span class="ml-1 text-[14px] text-[var(--gray-600)]" style="font-weight: 400">
-                  kg
-                </span>
-              </p>
-              <p class="mt-1 text-[12px] text-[var(--gray-500)]" style="font-weight: 400">
-                달성률 {{ progressPercentage.toFixed(0) }}%
               </p>
             </div>
           </template>

--- a/src/views/SignupView/SignupView.vue
+++ b/src/views/SignupView/SignupView.vue
@@ -5,12 +5,21 @@ import SignupFlow from '@/components/Signup/SignupFlow.vue'
 import type { SignupResult } from '@/types/signup'
 import { register } from '@/services/authService'
 import { buildRegisterPayload } from '@/utils/signupMapper'
+import { clearRegisterToken, getRegisterToken } from '@/services/registerTokenStore'
 
 const router = useRouter()
 const isSubmitting = ref(false)
 
 // OAuthCallback에서 전달받은 registerToken 확인
-const registerToken = history.state.registerToken as string | undefined
+const registerTokenFromState =
+  (
+    history.state as
+      | { registerToken?: string; state?: { registerToken?: string } }
+      | null
+      | undefined
+  )?.registerToken ??
+  (history.state as { state?: { registerToken?: string } } | null | undefined)?.state?.registerToken
+const registerToken = getRegisterToken() || registerTokenFromState
 
 if (!registerToken) {
   // 토큰 없이 직접 접근 시 로그인 페이지로 리다이렉트 (필요 시 활성화)
@@ -31,6 +40,7 @@ const handleComplete = async (payload: SignupResult) => {
 
   if (!registerToken) {
     alert('잘못된 접근입니다. 다시 로그인해주세요.')
+    clearRegisterToken()
     router.push('/login')
     return
   }
@@ -44,10 +54,12 @@ const handleComplete = async (payload: SignupResult) => {
     console.log('[Signup] register response', response)
 
     // 회원가입 후 로그인 성공 처리 -> 메인으로 이동
+    clearRegisterToken()
     router.push('/')
   } catch (error) {
     console.error('Signup failed:', error)
     alert('회원가입에 실패했습니다. 잠시 후 다시 시도해주세요.')
+    clearRegisterToken()
     router.push('/login')
   } finally {
     isSubmitting.value = false
@@ -55,6 +67,7 @@ const handleComplete = async (payload: SignupResult) => {
 }
 
 const handleExit = () => {
+  clearRegisterToken()
   router.push('/login')
 }
 </script>


### PR DESCRIPTION
 ## <i>PULL REQUEST</i>                                                                               
                                                                                                       
  ## feat: "Improve auth flow + diet UI"                                              
                                                                                                                                                                              
  ### 💡 작업동기                                                                                      
  - 로그인 미인증 접근 차단, 회원가입 플로우 유지, 식단 관련 UI/정보 표시 개선 필요                    
                                                                                                       
  ### 🔑 주요 변경사항                                                                                 
  - 로그인 전역 리다이렉트 강화 및 회원가입 토큰 플로우 보존                                           
  - 로그인 화면 회원가입 UI 제거                                                                       
  - 웰스토리/사내식단: 금주 식단표 탄·단·지 표시 추가                                                  
  - 식단 상세 모달: isEditable=false일 때 수정 버튼 숨김                                               
  - 홈 더미 데이터 초기값 0 처리, 마이페이지 체중/통계 텍스트 정리                                     
  - 파비콘을 헤더 로고 톤으로 교체                                                                     
  - 마이페이지 개인정보 소속 placeholder 문구 변경    